### PR TITLE
Search everywhere in the chat names

### DIFF
--- a/qml/pages/ChatList.qml
+++ b/qml/pages/ChatList.qml
@@ -129,7 +129,7 @@ Page {
                 },
                 RegExpFilter {
                     roleName: "name"
-                    pattern: "^" + searchField.text
+                    pattern: searchField.text
                     caseSensitivity: Qt.CaseInsensitive
                     enabled: searchField.text !== ""
                 }


### PR DESCRIPTION
Hi Michal, thank you for Yottagram. I really like the clean streamlined UI that keeps the noise down.

This PR changes the chat names filter to match everywhere, not just on the start of the name. This is the same behaviour that e.g. Telegram Desktop has and helps when you have a lot of chats with similar prefixes. That said, I know you probably put "^" there for a reason.